### PR TITLE
🚸 Check for login status before action due to persistent false

### DIFF
--- a/src/Background/index.ts
+++ b/src/Background/index.ts
@@ -114,6 +114,8 @@ browser.tabs.onActivated.addListener(async activeInfo => {
 });
 
 browser.browserAction.onClicked.addListener(async () => {
+  /* try to refresh login status first due to persistent: off */
+  if (!isLoggedIn) await checkLoginStatus();
   if (!isLoggedIn) {
     await loginViaLikerLand();
   } else {


### PR DESCRIPTION
probably background script's global var is reset after a while due to `persistent: off`
check for login status if isLogin is false