### PR TITLE
🐛 Remove unwanted querystring from youtube button

### DIFF
--- a/src/component/youtube/index.tsx
+++ b/src/component/youtube/index.tsx
@@ -75,7 +75,7 @@ function getCanonicalVideoURL() {
   const keys: string[] = Array.from(url.searchParams.keys());
   keys.filter(k => k !== 'v').forEach(k => {
     url.searchParams.delete(k);
-  })
+  });
   return url.toString();
 }
 

--- a/src/component/youtube/index.tsx
+++ b/src/component/youtube/index.tsx
@@ -67,6 +67,18 @@ interface Props {
   likerId: string;
 }
 
+function getCanonicalVideoURL() {
+  if (!window || !URL) return '';
+  const href = window && window.location.href;
+  const url = new URL(href);
+  // @ts-ignore
+  const keys: string[] = Array.from(url.searchParams.keys());
+  keys.filter(k => k !== 'v').forEach(k => {
+    url.searchParams.delete(k);
+  })
+  return url.toString();
+}
+
 function YoutubeButton(props: Props) {
   const { likerId } = props;
   const { t } = useTranslation();
@@ -77,6 +89,7 @@ function YoutubeButton(props: Props) {
   useEffect(() => {
     const likerButtonInstance = new LikerButton({
       likerId,
+      href: getCanonicalVideoURL(),
       ref: document.querySelector('.liker-button') as HTMLElement,
     });
     likerButtonInstance.mount();


### PR DESCRIPTION
Youtube might inject querystring like `t=0` `feature=youtube.com` etc into url, which when put into likecoin button url, a same video with different querystring will be treated as different content
This PR remove all querystring except `v` which stands for video ID