### PR TITLE
🌐 Fix like.co register url locale and add utm querystrings

### DIFF
--- a/src/component/youtube/index.tsx
+++ b/src/component/youtube/index.tsx
@@ -85,7 +85,7 @@ function YoutubeButton(props: Props) {
 
   const register = () => {
     const locale = t('LIKE_CO_LOCALE_KEY') || '';
-    window.open(`https://like.co/in/register?locale=${locale}`, '_blank');
+    window.open(`https://like.co/in/register?utm_source=browser_extension&locale=${locale}`, '_blank');
   };
   useEffect(() => {
     const likerButtonInstance = new LikerButton({

--- a/src/component/youtube/index.tsx
+++ b/src/component/youtube/index.tsx
@@ -84,7 +84,8 @@ function YoutubeButton(props: Props) {
   const { t } = useTranslation();
 
   const register = () => {
-    window.open(`https://like.co/in/register`, '_blank');
+    const locale = t('LIKE_CO_LOCALE_KEY') || '';
+    window.open(`https://like.co/in/register?locale=${locale}`, '_blank');
   };
   useEffect(() => {
     const likerButtonInstance = new LikerButton({

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -1,22 +1,25 @@
 const translation = {
   en: {
     translation: {
+      LIKE_CO_LOCALE_KEY: 'en',
       YOUTUBE_TITLE: 'Let YouTubers get rewarded by likes!',
-      YOUTUBE_STEP1: 'Register a Liker ID: https://like.co/in/register?language=en',
+      YOUTUBE_STEP1: 'Register a Liker ID: https://like.co/in/register',
       YOUTUBE_STEP2: 'Add the line "https://button.like.co/yourLikerID" at the end of the video description',
     },
   },
   'zh-CN': {
     translation: {
+      LIKE_CO_LOCALE_KEY: 'zh',
       YOUTUBE_TITLE: '按赞让 YouTuber 获得回报！',
-      YOUTUBE_STEP1: '注册 Liker ID： https://like.co/in/register?language=zh',
+      YOUTUBE_STEP1: '注册 Liker ID： https://like.co/in/register',
       YOUTUBE_STEP2: '在影片描述最后加上 https://button.like.co/yourLikerID',
     },
   },
   'zh-TW': {
     translation: {
+      LIKE_CO_LOCALE_KEY: 'zh',
       YOUTUBE_TITLE: '按讚讓 YouTuber 獲得回報！',
-      YOUTUBE_STEP1: '註冊 Liker ID： https://like.co/in/register?language=zh',
+      YOUTUBE_STEP1: '註冊 Liker ID： https://like.co/in/register',
       YOUTUBE_STEP2: '在影片描述最後加上 https://button.like.co/yourLikerID',
     },
   },

--- a/src/sdk/button.iframe.ts
+++ b/src/sdk/button.iframe.ts
@@ -38,7 +38,7 @@ class LikeCoinButton {
     this.ref.setAttribute('data-href', this.href);
 
     this.href = encodeURIComponent(this.href);
-    const src = `https://button.like.co/in/embed/${this.likerId}/button?referrer=${this.href}`;
+    const src = `https://button.like.co/in/embed/${this.likerId}/button?referrer=${this.href}&integration=browser_extension`;
     this.ref.textContent = '';
     this.ref.appendChild(document.createElement('div'));
     const iframe = document.createElement('iframe');

--- a/src/utils/api/likerland.ts
+++ b/src/utils/api/likerland.ts
@@ -34,5 +34,5 @@ export function logout() {
 }
 
 export const getOAuthLoginAPI = () => {
-  return `${LIKER_LAND_API_BASE}/users/login`;
+  return `${LIKER_LAND_API_BASE}/users/login?utm_source=browser_extension`;
 };


### PR DESCRIPTION
Currently despite the display of like.co register link has `locale` qs, the actual window opened does not have any locale string.
This PR fixes this by removing locale from display url, and add i18n logic into window.open
Also added some utm query string to track usage of plugin to like.co register